### PR TITLE
Correction to TwoHop circuit_generator

### DIFF
--- a/bwscanner/circuit.py
+++ b/bwscanner/circuit.py
@@ -79,7 +79,7 @@ class TwoHop(CircuitGenerator):
             """
             num_relays = len(self.relays)
             for i in random.sample(range(this_partition, num_relays, partitions),
-                                   num_relays):
+                                   num_relays/partitions):
                 relay = self.relays[i]
                 yield relay, self.exit_by_bw(relay)
 


### PR DESCRIPTION
here we correctly bound the call to random.sample and specify the correct
number of elements to sample is actually num_relays/partitions
NOT num_relays!
