### PR TITLE
Use Deferred semaphore to limit simultaneous measurements

### DIFF
--- a/bwscanner/measurement.py
+++ b/bwscanner/measurement.py
@@ -38,6 +38,8 @@ class BwScan(object):
         self.scan_continuous = kwargs.get('scan_continuous', False)
         self.request_timeout = kwargs.get('request_timeout', 60)
         self.circuit_launch_delay = kwargs.get('circuit_launch_delay', .2)
+        # Limit the number of simultaneous bandwidth measurements
+        self.request_limit = kwargs.get('request_limit', 10)
 
         self.tasks = []
         self.circuits = None
@@ -71,10 +73,12 @@ class BwScan(object):
             all_done.addCallback(lambda ign: self.run_scan())
         self.circuits = TwoHop(self.state, partitions=self.partitions,
                                this_partition=self.this_partition)
+        sem = defer.DeferredSemaphore(self.request_limit)
 
         def scan_over_next_circuit():
             try:
-                self.fetch(self.circuits.next())
+                task = sem.run(self.fetch, self.circuits.next())
+                self.tasks.append(task)
             except StopIteration:
                 # All circuit measurement tasks have been setup. Now wait for
                 # all tasks to complete before writing results, and firing
@@ -149,7 +153,7 @@ class BwScan(object):
         request.addCallbacks(get_circuit_bw)
         request.addErrback(circ_failure)
         request.addCallback(self.result_sink.send)
-        self.tasks.append(request)
+        return request
 
     @defer.inlineCallbacks
     def get_r_ns_bw(self, router):

--- a/bwscanner/scanner.py
+++ b/bwscanner/scanner.py
@@ -57,6 +57,9 @@ def cli(ctx, verbose, data_dir):
               help='Scan a particular subset / partition of the relays.')
 @click.option('--timeout', default=120,
               help='Timeout for measurement HTTP requests (default: %ds).' % 120)
+@click.option('--request-limit', default=10,
+              help='Limit the number of simultaneous bandwidth measurements '
+              '(default: %d).' % 10)
 @click.option('--launch-tor/--no-launch-tor', default=True,
               help='Launch Tor or try to connect to an existing Tor instance.')
 @click.option('--circuit-build-timeout', default=20,
@@ -65,7 +68,7 @@ def cli(ctx, verbose, data_dir):
               help='Option passed when launching Tor.')
 @pass_scan
 def scan(scan, launch_tor, partitions, current_partition, timeout,
-         circuit_build_timeout, circuit_idle_timeout):
+         request_limit, circuit_build_timeout, circuit_idle_timeout):
     """
     Start a scan through each Tor relay to measure it's bandwidth.
     """
@@ -108,7 +111,8 @@ def scan(scan, launch_tor, partitions, current_partition, timeout,
         os.makedirs(measurement_dir)
 
     tor.addCallback(BwScan, reactor, measurement_dir, request_timeout=timeout,
-                    partitions=partitions, this_partition=current_partition)
+                    request_limit=request_limit, partitions=partitions,
+                    this_partition=current_partition)
     tor.addCallback(lambda scanner: scanner.run_scan())
     tor.addCallback(lambda _: reactor.stop())
     reactor.run()


### PR DESCRIPTION
The bandwidth scanner was trying to launch all of its Tor measurement circuits as soon as possible. This will cause issues where the bandwidth and CPU limits of the measurement machine will distort the measured bandwidth values for the measured relays.

This commit adds a deferred semaphore and a command line option to limit the number of simultanious connections. The defaults is 10 but this should be changed if anyone has a better value.

Resolves #24.
