### PR TITLE
Allow the log level to be controlled from the command-line

### DIFF
--- a/bwscanner/circuit.py
+++ b/bwscanner/circuit.py
@@ -4,7 +4,7 @@ Classes used for choosing relay circuit paths
 import operator
 import random
 
-from twisted.python import log
+from bwscanner.logger import log
 
 
 class CircuitGenerator(object):
@@ -81,7 +81,7 @@ class TwoHop(CircuitGenerator):
             """
             num_relays = len(self.relays)
             relay_subset = range(this_partition-1, num_relays, partitions)
-            log.msg("Performing a measurement scan with %d relays." % len(relay_subset))
+            log.info("Performing a measurement scan with {count} relays.", count=len(relay_subset))
 
             # Choose relays in a random order fromm the relays in this partition set.
             for i in random.sample(relay_subset, len(relay_subset)):

--- a/bwscanner/logger.py
+++ b/bwscanner/logger.py
@@ -1,0 +1,34 @@
+import sys
+from twisted.internet.protocol import Factory
+from twisted.logger import (FileLogObserver, FilteringLogObserver, globalLogPublisher, Logger,
+                            LogLevel, LogLevelFilterPredicate, formatEvent, formatTime)
+from twisted.python.logfile import DailyLogFile
+
+
+def log_event_format(event):
+    return u"{0} [{1}]: {2}\n".format(formatTime(event["log_time"]),
+                                      event["log_level"].name.upper(),
+                                      formatEvent(event))
+
+# Disable Factory starting and stopping log messages
+Factory.noisy = False
+log = Logger("bwscanner")
+
+
+def setup_logging(log_level, log_name, log_directory=""):
+    """
+    Configure the logger to use the specified log file and log level
+    """
+    log_filter = LogLevelFilterPredicate()
+    log_filter.setLogLevelForNamespace("bwscanner", LogLevel.levelWithName(log_level.lower()))
+
+    # Set up logging
+    log_file = DailyLogFile(log_name, log_directory)
+    file_observer = FileLogObserver(log_file, log_event_format)
+    console_observer = FileLogObserver(sys.stdout, log_event_format)
+
+    file_filter_observer = FilteringLogObserver(file_observer, (log_filter,))
+    console_filter_observer = FilteringLogObserver(console_observer, (log_filter,))
+
+    globalLogPublisher.addObserver(file_filter_observer)
+    globalLogPublisher.addObserver(console_filter_observer)

--- a/bwscanner/scanner.py
+++ b/bwscanner/scanner.py
@@ -1,11 +1,10 @@
 import os
-import sys
 
 import click
 from twisted.internet import reactor
-from twisted.python import log
 from txtorcon import build_local_tor_connection, TorConfig
 
+from bwscanner.logger import setup_logging, log
 from bwscanner.attacher import start_tor, update_tor_config, FETCH_ALL_DESCRIPTOR_OPTIONS
 from bwscanner.measurement import BwScan
 
@@ -19,7 +18,6 @@ class ScanInstance(object):
     """
     def __init__(self, data_dir):
         self.data_dir = data_dir
-        self.verbose = False
 
     def __repr__(self):
         return '<BWScan %r>' % self.data_dir
@@ -28,15 +26,17 @@ pass_scan = click.make_pass_decorator(ScanInstance)
 
 
 @click.group()
-@click.option('--verbose/--no-verbose', default=False,
-              help='Enables verbose mode.')
 @click.option('--data-dir', type=click.Path(),
               default=os.environ.get("BWSCANNER_DATADIR", click.get_app_dir('bwscanner')),
               help='Directory where bwscan should stores its measurements and '
               'other data.')
+@click.option('-l', '--loglevel', help='The logging level the scanner will use (default: info)',
+              default='info', type=click.Choice(['debug', 'info', 'warn', 'error', 'critical']))
+@click.option('-f', '--logfile',  type=click.Path(), default='bwscanner.log',
+              help='The file the log will be written to')
 @click.version_option(BWSCAN_VERSION)
 @click.pass_context
-def cli(ctx, verbose, data_dir):
+def cli(ctx, data_dir, loglevel, logfile):
     """
     The bwscan tool measures Tor relays and calculates their bandwidth. These
     bandwidth measurements can then be aggregate to create the bandwidth
@@ -47,7 +47,9 @@ def cli(ctx, verbose, data_dir):
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
     ctx.obj = ScanInstance(data_dir)
-    ctx.obj.verbose = verbose
+
+    # Set up the logger to only output log lines of level `loglevel` and above.
+    setup_logging(log_level=loglevel, log_name=logfile)
 
 
 @cli.command(short_help="Measure the Tor relays.")
@@ -72,10 +74,7 @@ def scan(scan, launch_tor, partitions, current_partition, timeout,
     """
     Start a scan through each Tor relay to measure it's bandwidth.
     """
-    if scan.verbose:
-        log.startLogging(sys.stdout)
-        click.echo('Verbose log mode is on.')
-        click.echo('Using %s as the data directory.' % scan.data_dir)
+    log.info("Using {data_dir} as the data directory.", data_dir=scan.data_dir)
 
     # Options for spawned or running Tor to load the correct descriptors.
     tor_options = {
@@ -85,11 +84,11 @@ def scan(scan, launch_tor, partitions, current_partition, timeout,
     }
 
     def tor_status(tor):
-        click.echo("Connected to a Tor instance.")
+        log.info("Connected successfully to Tor.")
         return tor
 
     if launch_tor:
-        click.echo("Spawning a new Tor instance")
+        log.info("Spawning a new Tor instance.")
         c = TorConfig()
         # Update Tor config before launching a new Tor.
         c.config.update(tor_options)
@@ -97,7 +96,7 @@ def scan(scan, launch_tor, partitions, current_partition, timeout,
         tor = start_tor(c)
 
     else:
-        click.echo("Connecting to a running Tor instance")
+        log.info("Trying to connect to a running Tor instance.")
         tor = build_local_tor_connection(reactor)
         # Update the Tor config on a running Tor.
         tor.addCallback(update_tor_config, tor_options)
@@ -123,5 +122,5 @@ def aggregate():
     """
     Command to aggregate BW measurements to create file for the BWAuths
     """
-    click.echo('Aggregating bandwidth measurements')
-    click.echo('Not implemented yet')
+    log.info("Aggregating bandwidth measurements.")
+    log.warn("Not implemented yet!")

--- a/bwscanner/writer.py
+++ b/bwscanner/writer.py
@@ -2,8 +2,9 @@ import datetime
 import os.path
 import json
 
-from twisted.python import log
 from twisted.internet import threads, defer
+
+from bwscanner.logger import log
 
 
 class ResultSink(object):
@@ -64,7 +65,7 @@ class ResultSink(object):
                 json.dump(self.buffer, wf, sort_keys=True)
             finally:
                 wf.close()
-            log.msg("Finished writing measurement values to %s" % log_path)
+            log.info("Finished writing measurement values to {log_path}.", log_path=log_path)
 
         def maybe_do_work(result):
             if len(self.buffer) != 0:


### PR DESCRIPTION
This commit replaces the usage of old-style Twisted logging with
the newer `twisted.logger` and LoggingObserver interfaces. This
interface gives control over the log level of messages output.

This commit also disables the Factory start and stop log messages
which were polluting the command output.

Resolves #25.
