### PR TITLE
update pyOpenSSL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==6.6
-pyOpenSSL==16.0.0
+pyOpenSSL==16.2.0
 service-identity==16.0.0
 stem>=1.4.0
 Twisted==16.2.0


### PR DESCRIPTION
This is to fix AttributeError, missing attribute 'SSL_ST_INIT'.
e.g.:
https://stackoverflow.com/questions/43267157/python-attributeerror-module-object-has-no-attribute-ssl-st-init