### PR TITLE
add / for symlink

### DIFF
--- a/test/scripts/install-chutney.sh
+++ b/test/scripts/install-chutney.sh
@@ -10,7 +10,7 @@ cd chutney
 ./chutney status networks/basic-025
 
 # Retry verify until Tor circuit creation is working
-client_torrc=$(find net/nodes -wholename "*c/torrc" | head -n1)
+client_torrc=$(find net/nodes/ -wholename "*c/torrc" | head -n1)
 control_port=$(grep -Po -m1 "ControlPort\s(\d+)$" $client_torrc | awk '{print $2}')
 export CHUTNEY_CONTROL_PORT="$control_port"
 n=0


### PR DESCRIPTION
install-chutney.sh script doesn't find a torrc without trailing /

(replaces #50)