### PR TITLE
Prevent authorities from being selected in the exit position

### DIFF
--- a/bwscanner/circuit.py
+++ b/bwscanner/circuit.py
@@ -26,7 +26,8 @@ class CircuitGenerator(object):
 
         TODO: Check the exit policy
         """
-        return ('exit' in relay.flags and 'badexit' not in relay.flags)
+        is_exit = ('exit' in relay.flags and 'badexit' not in relay.flags)
+        return is_exit and 'authority' not in relay.flags
 
 
 class ExitScan(CircuitGenerator):


### PR DESCRIPTION
Authorities should never be measured or selected as exits ([#20797](https://trac.torproject.org/projects/tor/ticket/20797)). 

This change fixes a bug where authorities with the Exit flag but a `Reject *:*` exit policy were being selected as Exits. This caused random circuit failures in the tests.

The complete solution involves also reading the Exit policy to decide if a relay can exit to the `bwauth` server.