### PR TITLE
Refactor Tor connection and configuration code

### DIFF
--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -140,6 +140,7 @@ def update_tor_config(tor, config):
     """
     config_pairs = [(key, value) for key, value in config.items()]
     d = tor.protocol.set_conf(*itertools.chain.from_iterable(config_pairs))
+    d.addCallback(lambda ok: tor.protocol.get_conf("OrPort"))
     return d.addCallback(lambda result: tor)
 
 

--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -150,7 +150,7 @@ def setconf_singleport_exit(tor):
 
 
 @defer.inlineCallbacks
-def connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout, control_port=9051):
+def connect_to_tor(launch_tor, circuit_build_timeout, control_port=9051):
     """
     Launch or connect to a Tor instance
 
@@ -160,7 +160,6 @@ def connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout, cont
     tor_options = {
         'LearnCircuitBuildTimeout': 0,  # Disable adaptive circuit timeouts.
         'CircuitBuildTimeout': circuit_build_timeout,
-        'CircuitIdleTimeout': circuit_idle_timeout,
         'UseEntryGuards': 0,  # Disable UseEntryGuards to avoid PathBias warnings.
         'UseMicroDescriptors': 0,
         'FetchUselessDescriptors': 1,

--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -185,7 +185,7 @@ def connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout, cont
 
     else:
         log.info("Trying to connect to a running Tor instance.")
-        tor = build_local_tor_connection(reactor, port=control_port)
+        tor = build_tor_connection((reactor, '127.0.0.1', control_port,))
         # Update the Tor config on a running Tor.
         tor.addCallback(update_tor_config, tor_options)
 

--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -140,7 +140,7 @@ def update_tor_config(tor, config):
     """
     config_pairs = [(key, value) for key, value in config.items()]
     d = tor.protocol.set_conf(*itertools.chain.from_iterable(config_pairs))
-    d.addCallback(lambda ok: tor.protocol.get_conf("OrPort"))
+    d.addCallback(lambda ok: ok)
     return d.addCallback(lambda result: tor)
 
 

--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -176,10 +176,6 @@ def connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout, cont
         'FetchDirInfoExtraEarly': 1,
     }
 
-    def tor_status(tor):
-        log.info("Connected successfully to Tor.")
-        return tor
-
     if launch_tor:
         log.info("Spawning a new Tor instance.")
         c = TorConfig()
@@ -193,5 +189,6 @@ def connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout, cont
         # Update the Tor config on a running Tor.
         tor.addCallback(update_tor_config, tor_options)
 
-    tor.addCallback(tor_status)
+    tor.addErrback(log.debug)
+
     return tor

--- a/bwscanner/circuit.py
+++ b/bwscanner/circuit.py
@@ -31,7 +31,7 @@ def random_path_to_exit(exit_relay, relays):
 class CircuitGenerator(object):
     def __init__(self, state):
         self.state = state
-        self.relays = list(set(state.routers.values()))
+        self.relays = list(set(r for r in state.routers.values() if r))
         self.exits = [relay for relay in self.relays if is_valid_exit(relay)]
 
     def __iter__(self):

--- a/bwscanner/fetcher.py
+++ b/bwscanner/fetcher.py
@@ -66,7 +66,7 @@ class OnionRoutedTCPClientEndpoint(object):
 
         def _create_circ(proto):
             hp = proto.transport.getHost()
-            d = self.state.attacher.create_circuit(hp.host, hp.port, self.path)
+            d = self.state._attacher.create_circuit(hp.host, hp.port, self.path)
             d.addErrback(proxy_factory.deferred.errback)
             return proxy_factory.deferred
 

--- a/bwscanner/scanner.py
+++ b/bwscanner/scanner.py
@@ -42,11 +42,9 @@ pass_scan = click.make_pass_decorator(ScanInstance)
               help='Launch Tor or try to connect to an existing Tor instance.')
 @click.option('--circuit-build-timeout', default=20,
               help='Option passed when launching Tor.')
-@click.option('--circuit-idle-timeout', default=20,
-              help='Option passed when launching Tor.')
 @click.version_option(BWSCAN_VERSION)
 @click.pass_context
-def cli(ctx, data_dir, loglevel, logfile, launch_tor, circuit_build_timeout, circuit_idle_timeout):
+def cli(ctx, data_dir, loglevel, logfile, launch_tor, circuit_build_timeout):
     """
     The bwscan tool measures Tor relays and calculates their bandwidth. These
     bandwidth measurements can then be aggregate to create the bandwidth
@@ -60,7 +58,7 @@ def cli(ctx, data_dir, loglevel, logfile, launch_tor, circuit_build_timeout, cir
         os.makedirs(ctx.obj.measurement_dir)
 
     # Create a connection to a Tor instance
-    ctx.obj.tor = connect_to_tor(launch_tor, circuit_build_timeout, circuit_idle_timeout)
+    ctx.obj.tor = connect_to_tor(launch_tor, circuit_build_timeout)
 
     # Set up the logger to only output log lines of level `loglevel` and above.
     setup_logging(log_level=loglevel, log_name=logfile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ service-identity==16.0.0
 stem>=1.4.0
 Twisted==16.2.0
 txsocksx==1.15.0.2
-txtorcon==0.15.0
+txtorcon==0.19.3

--- a/test/template.py
+++ b/test/template.py
@@ -16,13 +16,6 @@ class TorTestCase(unittest.TestCase):
                 launch_tor=False,
                 control_port=int(os.environ.get('CHUTNEY_CONTROL_PORT')),
                 circuit_build_timeout=30,
-                # XXX: Avoid switching to regular descriptors in tests.
-                #      There is a race condition where the tests can
-                #      start running while the new consensus is still
-                #      being fetched and loaded by Txtorcon.
-                #
-                #      We should find a solution for this race.
-                tor_overrides={'UseMicroDescriptors': 1},
         )
 
         self.attacher = SOCKSClientStreamAttacher(self.tor_state)

--- a/test/template.py
+++ b/test/template.py
@@ -15,7 +15,6 @@ class TorTestCase(unittest.TestCase):
         self.tor_state = yield connect_to_tor(
                 launch_tor=False,
                 circuit_build_timeout=30,
-                circuit_idle_timeout=30,
                 control_port=int(os.environ.get('CHUTNEY_CONTROL_PORT')))
 
         self.attacher = SOCKSClientStreamAttacher(self.tor_state)

--- a/test/template.py
+++ b/test/template.py
@@ -12,18 +12,18 @@ class TorTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.tor = yield connect_to_tor(
+        self.tor_state = yield connect_to_tor(
                 launch_tor=False,
                 circuit_build_timeout=30,
                 circuit_idle_timeout=30,
                 control_port=int(os.environ.get('CHUTNEY_CONTROL_PORT')))
 
-        self.attacher = SOCKSClientStreamAttacher(self.tor)
-        yield self.tor.set_attacher(self.attacher, reactor)
+        self.attacher = SOCKSClientStreamAttacher(self.tor_state)
+        yield self.tor_state.set_attacher(self.attacher, reactor)
 
     @property
     def routers(self):
-        return list(set(self.tor.routers.values()))
+        return list(set(self.tor_state.routers.values()))
 
     @property
     def exits(self):
@@ -35,7 +35,7 @@ class TorTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tor.set_attacher(None, reactor)
-        yield self.tor.protocol.quit()
+        yield self.tor_state.set_attacher(None, reactor)
+        yield self.tor_state.protocol.quit()
         # seems to leave dirty reactor otherwise?
-        yield self.tor.protocol.transport.loseConnection()
+        yield self.tor_state.protocol.transport.loseConnection()

--- a/test/template.py
+++ b/test/template.py
@@ -2,21 +2,21 @@ import os
 import random
 
 from twisted.internet import defer, reactor
-from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.trial import unittest
-from txtorcon.torstate import build_tor_connection
 
 from bwscanner import circuit
-from bwscanner.attacher import SOCKSClientStreamAttacher
+from bwscanner.attacher import SOCKSClientStreamAttacher, connect_to_tor
 
 
 class TorTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.tor = yield build_tor_connection(
-            TCP4ClientEndpoint(reactor, 'localhost', int(
-                os.environ.get('CHUTNEY_CONTROL_PORT'))))
+        self.tor = yield connect_to_tor(
+                launch_tor=False,
+                circuit_build_timeout=30,
+                circuit_idle_timeout=30,
+                control_port=int(os.environ.get('CHUTNEY_CONTROL_PORT')))
 
         self.attacher = SOCKSClientStreamAttacher(self.tor)
         yield self.tor.set_attacher(self.attacher, reactor)

--- a/test/test_attacher.py
+++ b/test/test_attacher.py
@@ -54,7 +54,7 @@ class TestSOCKSClientStreamAttacher(TorTestCase):
     def setUp(self):
         yield super(TestSOCKSClientStreamAttacher, self).setUp()
         # do not attach circuits automatically
-        yield self.tor.set_attacher(None, reactor)
+        yield self.tor_state.set_attacher(None, reactor)
 
     @defer.inlineCallbacks
     def test_create_circuit(self):

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -8,7 +8,7 @@ class TestCircuitGenerators(TorTestCase):
         all_exits = set(self.exits)
         num_circuits = 0
         seen = set()
-        for circuit in ExitScan(self.tor):
+        for circuit in ExitScan(self.tor_state):
             assert len(circuit) == 3
             assert 'exit' in circuit[-1].flags
             seen.add(circuit[-1])
@@ -20,7 +20,7 @@ class TestCircuitGenerators(TorTestCase):
         all_r = set(self.routers)
         num_circuits = 0
         seen = set()
-        for circuit in TwoHop(self.tor):
+        for circuit in TwoHop(self.tor_state):
             assert len(circuit) == 2
             assert 'exit' in circuit[-1].flags
             num_circuits = num_circuits + 1

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -32,15 +32,15 @@ class TestOnionRoutedTCPClientEndpoint(TorTestCase):
     def test_connect_tcp(self):
         endpoint = random.choice(self.routers)
         # Connect to a routers OR port as a general TCP connection test
-        ore = OnionRoutedTCPClientEndpoint(endpoint.ip, int(endpoint.or_port),
-                                           self.tor, self.random_path())
+        ore = OnionRoutedTCPClientEndpoint(str(endpoint.ip), int(endpoint.or_port),
+                                           self.tor_state, self.random_path())
         proto = yield ore.connect(MockProtocol())
         self.failUnlessIsInstance(proto, MockProtocol)
 
     @defer.inlineCallbacks
     def test_connect_tcp_fail(self):
         ore = OnionRoutedTCPClientEndpoint('127.0.0.1', 3,
-                                           self.tor, self.random_path())
+                                           self.tor_state, self.random_path())
         with self.assertRaises(ConnectionRefused):
             yield ore.connect(MockProtocol())
 
@@ -63,7 +63,7 @@ class TestOnionRoutedAgent(TorTestCase):
     @defer.inlineCallbacks
     def test_do_request(self):
         agent = OnionRoutedAgent(reactor, path=self.random_path(),
-                                 state=self.tor)
+                                 state=self.tor_state)
         url = "http://127.0.0.1:{}".format(self.port)
         request = yield agent.request("GET", url)
         body = yield readBody(request)
@@ -72,7 +72,7 @@ class TestOnionRoutedAgent(TorTestCase):
     @defer.inlineCallbacks
     def test_do_failing_request(self):
         agent = OnionRoutedAgent(reactor, path=self.random_path(),
-                                 state=self.tor)
+                                 state=self.tor_state)
 
         url = "http://127.0.0.1:{}".format(3)
         with self.assertRaises(ConnectionRefused):

--- a/test/test_measurement.py
+++ b/test/test_measurement.py
@@ -36,7 +36,7 @@ class TestBwscan(TorTestCase):
     def test_scan_chutney(self):
         # check that each run is producing the same input set!
         self.tmp = mkdtemp()
-        scan = BwScan(self.tor, reactor, self.tmp)
+        scan = BwScan(self.tor_state, reactor, self.tmp)
         scan.baseurl = 'http://127.0.0.1:{}'.format(self.port)
 
         def check_all_routers_measured(measurement_dir):

--- a/test/test_measurement.py
+++ b/test/test_measurement.py
@@ -2,7 +2,6 @@ from twisted.internet import defer, reactor
 from twisted.web.resource import Resource
 from twisted.web.server import Site
 from txtorcon.util import available_tcp_port
-from bwscanner.attacher import update_tor_config, FETCH_ALL_DESCRIPTOR_OPTIONS
 from bwscanner.measurement import BwScan
 from test.template import TorTestCase
 from tempfile import mkdtemp
@@ -18,7 +17,6 @@ class TestBwscan(TorTestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield super(TestBwscan, self).setUp()
-        yield update_tor_config(self.tor, FETCH_ALL_DESCRIPTOR_OPTIONS)
 
         class DummyResource(Resource):
             isLeaf = True


### PR DESCRIPTION
This PR primarily refactors how connections are made to the Tor control port. The code now uses the `Txtorcon` high-level interfaces to either run a new Tor daemon or to connect to a running Tor (`txtorcon.launch` and `txtorcon.connect` respectively). Both the unit tests and main tool now use the same Tor connection interface.

Tor configuration options are now applied via the Txtorcon `TorConfig` object which handles marking changed options and applying the changes all at one. There was an issue when setting the `UseMicroDescriptors` option as this would cause Tor to throw away its descriptors and request new ones. As a result the tests would fail when they were run before all the descriptors were received.

The fix was to wait for a `NEWCONSENSUS` event after changing an option that required a consensus be loaded.

This PR also fixes some other small issues and renames the `self.tor` TorState object to `self.tor_state` to make the code more clear.

