### PR TITLE
Enable TestBwscan test

### DIFF
--- a/test/test_measurement.py
+++ b/test/test_measurement.py
@@ -12,11 +12,12 @@ from shutil import rmtree
 
 
 class TestBwscan(TorTestCase):
-    skip = "broken tests"
-
     @defer.inlineCallbacks
     def setUp(self):
         yield super(TestBwscan, self).setUp()
+
+        # Remove test harness attacher as another attacher is added in BwScan()
+        self.tor_state.set_attacher(None, reactor)
 
         class DummyResource(Resource):
             isLeaf = True


### PR DESCRIPTION
This PR enables the TestBwScan integration test. This test used to succeed but then hang the tests and never cleanly finish. Updating the Txtorcon version may have fixed the hanging issue as the test now works. 