### PR TITLE
Upgrade pyOpenSSL version as previous on fails verifying certs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==6.6
-pyOpenSSL==16.2.0
+pyOpenSSL==17.5.0
 service-identity==16.0.0
 stem>=1.4.0
 Twisted==16.2.0


### PR DESCRIPTION
Fix #75 