### PR TITLE
Remove DisableDebuggerAttachment option

### DIFF
--- a/bwscanner/attacher.py
+++ b/bwscanner/attacher.py
@@ -153,7 +153,6 @@ def connect_to_tor(launch_tor, circuit_build_timeout, control_port=None,
         'FetchDirInfoExtraEarly': 1,
         'SafeLogging': 0,
         'LogTimeGranularity': 1,
-        'DisableDebuggerAttachment': 0,
     }
 
     if tor_overrides:


### PR DESCRIPTION
DisableDebuggerAttachment was added in 839fc5a but it doesn't work when applied to an already running Tor (#80). This option can only be set before Tor is launched. I'm removing it for now as I don't see why it is needed when running the bwscanner.

Resolves #80.