### PR TITLE
Aggregate fixes

### DIFF
--- a/bwscanner/aggregate.py
+++ b/bwscanner/aggregate.py
@@ -70,7 +70,7 @@ def write_aggregate_data(tor, scan_dirs, file_name="aggregate_measurements"):
             routerstatus_info = yield tor.protocol.get_info_raw('ns/id/' + relay_fp.lstrip("$"))
             descriptor_info = yield tor.protocol.get_info_raw('desc/id/' + relay_fp.lstrip("$"))
         except TorProtocolError:
-            log.info("Relay {} not found in consensus!", relay_fp)
+            log.info("Relay {fp} not found in consensus!", fp=relay_fp)
             continue
 
         relay_routerstatus = RouterStatusEntryV3(routerstatus_info)

--- a/bwscanner/aggregate.py
+++ b/bwscanner/aggregate.py
@@ -4,6 +4,7 @@ import glob
 import json
 
 from twisted.internet.defer import inlineCallbacks
+from txtorcon.torcontrolprotocol import TorProtocolError
 from stem.descriptor.server_descriptor import RelayDescriptor
 from stem.descriptor.router_status_entry import RouterStatusEntryV3
 

--- a/bwscanner/aggregate.py
+++ b/bwscanner/aggregate.py
@@ -65,8 +65,13 @@ def write_aggregate_data(tor, scan_dirs, file_name="aggregate_measurements"):
             log.debug("Could not calculate a valid filtered bandwidth, skipping relay.")
             continue
 
-        routerstatus_info = yield tor.protocol.get_info_raw('ns/id/' + relay_fp.lstrip("$"))
-        descriptor_info = yield tor.protocol.get_info_raw('desc/id/' + relay_fp.lstrip("$"))
+        try:
+            routerstatus_info = yield tor.protocol.get_info_raw('ns/id/' + relay_fp.lstrip("$"))
+            descriptor_info = yield tor.protocol.get_info_raw('desc/id/' + relay_fp.lstrip("$"))
+        except TorProtocolError:
+            log.info("Relay {} not found in consensus!", relay_fp)
+            continue
+
         relay_routerstatus = RouterStatusEntryV3(routerstatus_info)
         relay_descriptor = RelayDescriptor(descriptor_info)
 


### PR DESCRIPTION
relays that aren't currently in the consensus raise a TorProtocolError; this changes the behavior to skip these relays while processing.